### PR TITLE
Hide access key

### DIFF
--- a/app/src/main/java/de/perflyst/untis/activity/ActivityPreferences.java
+++ b/app/src/main/java/de/perflyst/untis/activity/ActivityPreferences.java
@@ -336,7 +336,7 @@ public class ActivityPreferences extends de.perflyst.untis.activity.appcompat.Ac
 			final SharedPreferences prefs = getActivity()
 					.getSharedPreferences("login_data", MODE_PRIVATE);
 			Preference prefKey = findPreference("preference_account_access_key");
-			prefKey.setSummary(prefs.getString("key", "UNKNOWN"));
+			prefKey.setSummary("****************");
 			prefKey.setOnPreferenceClickListener(preference -> {
 				ClipboardManager clipboard = (ClipboardManager) getActivity()
 						.getSystemService(Context.CLIPBOARD_SERVICE);


### PR DESCRIPTION
I think the access key should be hidden like in the first login screen.