### PR TITLE
Make it work on Android 4.2 (and maybe lower)

### DIFF
--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -17,14 +17,14 @@
 		android:clickable="true"
 		android:focusable="true">
 
-		<ImageView
+		<android.support.v7.widget.AppCompatImageView
 			android:id="@+id/ivSelectDate"
 			android:layout_width="match_parent"
 			android:layout_height="match_parent"
 			android:background="?attr/selectableItemBackgroundBorderless"
 			android:contentDescription="@string/jump_to_date"
 			android:padding="4dp"
-			android:tint="?android:attr/textColorSecondary"
+			app:tint="?android:attr/textColorSecondary"
 			app:srcCompat="@drawable/ic_calendar"/>
 
 	</RelativeLayout>

--- a/app/src/main/res/layout/dialog_timetable_item_detail_page.xml
+++ b/app/src/main/res/layout/dialog_timetable_item_detail_page.xml
@@ -27,7 +27,7 @@
 		android:layout_height="wrap_content"
 		android:orientation="horizontal">
 
-		<ImageView
+		<android.support.v7.widget.AppCompatImageView
 			android:layout_width="wrap_content"
 			android:layout_height="wrap_content"
 			android:layout_marginBottom="12dp"
@@ -37,7 +37,7 @@
 			android:layout_marginStart="12dp"
 			android:layout_marginTop="12dp"
 			android:contentDescription="@string/teachers"
-			android:tint="?android:attr/textColorPrimary"
+			app:tint="?android:attr/textColorPrimary"
 			app:srcCompat="@drawable/ic_teacher"/>
 
 		<HorizontalScrollView
@@ -64,7 +64,7 @@
 		android:layout_height="wrap_content"
 		android:orientation="horizontal">
 
-		<ImageView
+		<android.support.v7.widget.AppCompatImageView
 			android:layout_width="wrap_content"
 			android:layout_height="wrap_content"
 			android:layout_marginBottom="12dp"
@@ -74,7 +74,7 @@
 			android:layout_marginStart="12dp"
 			android:layout_marginTop="12dp"
 			android:contentDescription="@string/classes"
-			android:tint="?android:attr/textColorPrimary"
+			app:tint="?android:attr/textColorPrimary"
 			app:srcCompat="@drawable/ic_classes"/>
 
 		<HorizontalScrollView
@@ -101,7 +101,7 @@
 		android:layout_height="wrap_content"
 		android:orientation="horizontal">
 
-		<ImageView
+		<android.support.v7.widget.AppCompatImageView
 			android:layout_width="wrap_content"
 			android:layout_height="wrap_content"
 			android:layout_marginBottom="12dp"
@@ -111,7 +111,7 @@
 			android:layout_marginStart="12dp"
 			android:layout_marginTop="12dp"
 			android:contentDescription="@string/rooms"
-			android:tint="?android:attr/textColorPrimary"
+			app:tint="?android:attr/textColorPrimary"
 			app:srcCompat="@drawable/ic_rooms"/>
 
 		<HorizontalScrollView

--- a/app/src/main/res/layout/dialog_timetable_item_detail_page_info.xml
+++ b/app/src/main/res/layout/dialog_timetable_item_detail_page_info.xml
@@ -6,7 +6,7 @@
 	android:layout_height="wrap_content"
 	android:orientation="horizontal">
 
-	<ImageView
+	<android.support.v7.widget.AppCompatImageView
 		android:layout_width="wrap_content"
 		android:layout_height="wrap_content"
 		android:layout_marginBottom="12dp"
@@ -16,7 +16,7 @@
 		android:layout_marginStart="12dp"
 		android:layout_marginTop="12dp"
 		android:contentDescription="@string/infos"
-		android:tint="?android:attr/textColorPrimary"
+		app:tint="?android:attr/textColorPrimary"
 		app:srcCompat="@drawable/ic_info"/>
 
 	<TextView

--- a/app/src/main/res/layout/list_item_features.xml
+++ b/app/src/main/res/layout/list_item_features.xml
@@ -30,7 +30,7 @@
 		android:textColor="?android:attr/textColorSecondary"
 		android:textSize="16sp"/>
 
-	<ImageView
+	<android.support.v7.widget.AppCompatImageView
 		android:id="@+id/ivDragHandle"
 		android:layout_width="32dp"
 		android:layout_height="32dp"
@@ -38,7 +38,7 @@
 		android:layout_alignParentRight="true"
 		android:layout_centerVertical="true"
 		android:contentDescription="@string/drag_to_sort"
-		android:tint="?android:attr/textColorSecondary"
+		app:tint="?android:attr/textColorSecondary"
 		app:srcCompat="@drawable/ic_drag_handle"/>
 
 </RelativeLayout>


### PR DESCRIPTION
When trying to open it on an Android 4.2 device (either real or emulated), the app would crash after logging in (before showing the time table).

Using an debugger, I found out that it throws an NumberFormatException about an attribute.
The fix is based of [this StackOverflow answer](https://stackoverflow.com/questions/46378259/imageview-tint-below-l-cannot-reference-theme-attribute/46433574#46433574). I just did a find&replace, which seems to work.

Note that I [found at least one instance](https://github.com/Perflyst/OpenUntis/blob/e4bcd6982c1dd63a15884a6592150773e5f3c3e9/app/src/main/res/layout/dialog_timetable_item_detail_page_info.xml#L22-L32) where the `android:tint="?android:attr/textColorPrimary"` is still being used. I am not sure where this comes up, so I couldn't really test it. I mostly cared about viewing the time table, which seems to display fine, on 4.2 and a newer Android.

Feel free to also create a PR for upstream (BetterUntis).

<sub>Note that on Android 4.2, there is a separator-line above the subject when you click on a block (like there is an empty title, the separator, and then the actual content, in this case the subject, room, and so on). This is not present on the newer Android version. I won't investigate because all I wanted to to was to fix this issue, since the official app also stopped working like that before it went incompatible (and I don't want to invest more time into Android development for now).</sub>
