### PR TITLE
Fix string format showing 10:0 instead of 10:00

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -78,7 +78,7 @@
 	<string name="notification_rooms">Raum: %1$s</string>
 	<string name="notification_teachers">Lehrer: %1$s</string>
 	<string name="close">Schließen</string>
-	<string name="notification_title">Pause bis: %1$d:%2$d</string>
+	<string name="notification_title">Pause bis: %1$02d:%2$02d</string>
 	<string name="pref_infos">Infos</string>
 	<string name="app_version_full">%1$s (%2$d)</string>
 	<string name="preference_account_access_key">Zugriffsschlüssel</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -78,7 +78,7 @@
 	<string name="notification_rooms">Aula: %1$s</string>
 	<string name="notification_teachers">Profesor/a: %1$s</string>
 	<string name="close">Cerrar</string>
-	<string name="notification_title">Descanso hasta las %1$d%2$d</string>
+	<string name="notification_title">Descanso hasta las %1$02d%2$02d</string>
 	<string name="pref_infos">Acerca de</string>
 	<string name="app_version_full">%1$s (%2$d)</string>
 	<string name="preference_account_access_key">Clave de acceso</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,7 +81,7 @@
 	<string name="preference_notifications_multiple">Enable in multiple-hour lesson</string>
 	<string name="preference_notifications_multiple_desc">Notifications will be shown in breaks within multiple-hour lessons.</string>
 	<string name="give_feedback">Give Feedback</string>
-	<string name="notification_title">Break until %1$d:%2$d</string>
+	<string name="notification_title">Break until %1$02d:%2$02d</string>
 	<string name="notification_subjects">Next lesson: %1$s</string>
 	<string name="notification_rooms">Room: %1$s</string>
 	<string name="notification_teachers">Teacher: %1$s</string>


### PR DESCRIPTION
Didn't explicitly test, but the fix seems simple enough. This message appears as a notification in the breaks.

The formatting string used was basically `%d`, on which formats `0` as `0`, causing the time to be formatted as `10:0` rather than `10:00`. The `2` in `%02d` say that it it at least 2 digits "big" and fill the empty space with `0`.

I've also applied to the es translation, where I also noticed that it doesn't have a `:` (colon). I am not sure if that is intentional or not.