### PR TITLE
fixed OpenUntis supporting every link

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,7 +37,7 @@
 				<data
 					android:path="/apps/OpenUntis/timetable"
 					android:scheme="https"
-					tools:ignore="AppLinkUrlError" />
+					android:host="*" />
 			</intent-filter>
 		</activity>
 


### PR DESCRIPTION
This PR replaces an attribute in the manifest which tells Android Studio/InteliJ to ignore errors, with an attribute which contains a valid host to make sure there is no error in the first place. For me this fixes an Issue with OpenUntis beeing able to open every link.