### PR TITLE
Fix problem with timetables that have days with varying number of units.

### DIFF
--- a/app/src/main/java/de/perflyst/untis/utils/timetable/TimegridUnitManager.java
+++ b/app/src/main/java/de/perflyst/untis/utils/timetable/TimegridUnitManager.java
@@ -12,6 +12,7 @@ public class TimegridUnitManager {
 	private ArrayList<UnitData> unitList;
 	private JSONArray days;
 	private int numberOfDays = -1;
+	private int longestDay = 0;
 	private int maxHoursPerDay = -1;
 
 	public TimegridUnitManager(JSONArray days) {
@@ -31,8 +32,12 @@ public class TimegridUnitManager {
 
 		for (int i = 0; i < days.length(); i++)
 			try {
-				maxHoursPerDay = Math.max(maxHoursPerDay, days.getJSONObject(i)
-						.getJSONArray("units").length());
+				final int unitsLength = days.getJSONObject(i).getJSONArray("units").length();
+				if (maxHoursPerDay < unitsLength) {
+					maxHoursPerDay = unitsLength;
+					// remember the day with the most units
+					longestDay = i;
+				}
 			} catch (JSONException e) {
 				e.printStackTrace();
 			}
@@ -46,9 +51,12 @@ public class TimegridUnitManager {
 
 	public ArrayList<UnitData> getUnits() {
 		if (unitList == null) {
+			// determine the number of days and longest day in the week before building list of units
+			// (important if week has days with different length)
+			calculateCounts();
 			unitList = new ArrayList<>();
 			try {
-				JSONArray units = days.getJSONObject(0).getJSONArray("units");
+				JSONArray units = days.getJSONObject(longestDay).getJSONArray("units");
 				for (int i = 0; i < units.length(); i++) {
 					UnitData unitData = new UnitData(
 							units.getJSONObject(i).getString("startTime").substring(1),


### PR DESCRIPTION
The timetable at my school has a varying number of units per day. Tuesday has 18 units, all other weekdays have 16 units. Because OpenUntis always uses the first day in the data to determine the number of units, an IndexOutOfBoundsException is thrown.

This PR fixes the problem by selecting the longest day in the timetable data to determine the number of units. For timetables with equal number of units for all days it should not cause any problems. 